### PR TITLE
Pass "--account" option

### DIFF
--- a/src/op.rs
+++ b/src/op.rs
@@ -13,6 +13,7 @@ impl TokenCache {
         let output = Command::new("op")
             .arg("signin")
             .arg("--raw")
+            .arg("--account")
             .arg(account)
             .stdout(Stdio::piped())
             .stdin(Stdio::inherit())


### PR DESCRIPTION
- opc git hush: 8d9f54db0ab2d823a0894909a22b18219ff36852
- op version: 2.3.1

I get the following error when I run the opc command:

```
Usage:  op signin [flags]

Examples:
Sign in and set the environment variable in one step:

	eval $(op signin --account acme.1password.com)

Flags:
  -f, --force   Ignore warnings and print raw output from this command.
...
```

It seems that the current op command requires the `--account` option to be passed:

```
% op signin xxx
[ERROR] 2022/05/29 11:05:33 expected at most 0 arguments but got 1 instead
Usage:  op signin [flags]

Examples:
Sign in and set the environment variable in one step:

	eval $(op signin --account acme.1password.com)

Flags:
  -f, --force   Ignore warnings and print raw output from this com
...
```

So I modified it to pass the `--account` option when calling the op command.
